### PR TITLE
feat: Support secrets via docker/build-push-action

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,11 @@ Only GitHub Container Registry (ghcr.io) is supported so far.
     # Specify token (GH or PAT), instead of inheriting one from the calling workflow
     token: ${{ secrets.GITHUB_TOKEN }}
 
+    # Multiline input for secrets to mount with Docker BuildKit.
+    # https://docs.docker.com/build/ci/github-actions/secrets/#secret-mounts
+    secrets: |
+        MY_SECRET=secret_value
+        ANOTHER_SECRET=another_value
 
     ### Deprecated
 

--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ Only GitHub Container Registry (ghcr.io) is supported so far.
     # Specify token (GH or PAT), instead of inheriting one from the calling workflow
     token: ${{ secrets.GITHUB_TOKEN }}
 
-    # Multiline input for secrets to mount with Docker BuildKit.
+    # Multiline input for secrets to mount.
     # https://docs.docker.com/build/ci/github-actions/secrets/#secret-mounts
     secrets: |
         MY_SECRET=secret_value

--- a/action.yml
+++ b/action.yml
@@ -56,7 +56,7 @@ inputs:
     default: ${{ github.token }}
   secrets:
     description: |
-      Multiline input for secrets to mount with Docker BuildKit.
+      Multiline input for secrets to mount.
       https://docs.docker.com/build/ci/github-actions/secrets/#secret-mounts
       Example: |
         MY_SECRET=secret_value

--- a/action.yml
+++ b/action.yml
@@ -33,6 +33,11 @@ inputs:
         test
   triggers:
     description: Paths used to trigger a build; e.g. ('./backend/' './frontend/)
+  secrets:
+    description: |
+      Multiline input for secrets to mount with Docker BuildKit.
+      Format: id=SECRET_ID,src=path/to/file (one per line).
+    required: false
 
   ### Usually a bad idea / not recommended
   build_args:
@@ -173,6 +178,7 @@ runs:
         cache-from: type=gha
         cache-to: type=gha,mode=max
         build-args: ${{ inputs.build_args }}
+        secrets: ${{ inputs.secrets }}
 
     - name: Install Syft
       if: steps.build.outputs.triggered == 'true' && inputs.sbom == 'true'

--- a/action.yml
+++ b/action.yml
@@ -33,11 +33,7 @@ inputs:
         test
   triggers:
     description: Paths used to trigger a build; e.g. ('./backend/' './frontend/)
-  secrets:
-    description: |
-      Multiline input for secrets to mount with Docker BuildKit.
-      Format: id=SECRET_ID,src=path/to/file (one per line).
-    required: false
+
 
   ### Usually a bad idea / not recommended
   build_args:
@@ -58,6 +54,11 @@ inputs:
   token:
     description: Specify token (GH or PAT), instead of inheriting one from the calling workflow
     default: ${{ github.token }}
+  secrets:
+    description: |
+      Multiline input for secrets to mount with Docker BuildKit.
+      https://docs.docker.com/build/ci/github-actions/secrets/#secret-mounts
+    required: false
 
 outputs:
   digest:

--- a/action.yml
+++ b/action.yml
@@ -58,7 +58,9 @@ inputs:
     description: |
       Multiline input for secrets to mount with Docker BuildKit.
       https://docs.docker.com/build/ci/github-actions/secrets/#secret-mounts
-    required: false
+      Example: |
+        MY_SECRET=secret_value
+        ANOTHER_SECRET=another_value
 
 outputs:
   digest:


### PR DESCRIPTION
This pull request adds support for securely passing secrets to Docker builds using the `docker/build-push-action@v6` secret mount feature.

Introduces a new multiline 'secrets' input in `action.yml`, allowing users to specify secrets in the format required.

This has been tested on Epsilon's test branch implementing this github action as we're attempting to move away form build configs. (If you have access, here is the [successful build](https://github.com/bcgov-c/epsilon-explore-by-location/actions/runs/16279293864/job/45965471206#step:2:891) and [workflow](https://github.com/bcgov-c/epsilon-explore-by-location/actions/runs/16279293864/workflow#L37))

A publicly visible test is [here](https://github.com/dmarcantonio/gh-abcs-actions/actions/runs/15914920612/workflow)

## References:
Issue: https://github.com/bcgov/action-builder-ghcr/issues/98
Docker secret mounts: https://docs.docker.com/build/ci/github-actions/secrets/#secret-mounts
